### PR TITLE
Add support for OpenSSL, improve base image and build script

### DIFF
--- a/Dockerfile.rust
+++ b/Dockerfile.rust
@@ -4,7 +4,7 @@ ENV PATH /home/rust/.cargo/bin:/freebsd/bin:/usr/local/sbin:/usr/local/bin:/usr/
 
 RUN apt-get -y update && \
     apt-get -y install curl build-essential
-# A host compiler is needed to link Rust uild scripts even when cross compiling
+# A host compiler is needed to link Rust build scripts even when cross compiling
 
 RUN useradd -ms /bin/bash rust
 
@@ -18,6 +18,8 @@ RUN mkdir -p /home/rust/code/target /home/rust/.cargo/registry /home/rust/output
 WORKDIR /home/rust/code
 
 VOLUME /home/rust/code /home/rust/code/target /home/rust/output /home/rust/.cargo/registry
+
+env OPENSSL_DIR /freebsd/x86_64-pc-freebsd12/ # required for the openssl-sys crate
 
 ENTRYPOINT ["cargo"]
 CMD ["--help"]

--- a/Dockerfile.rust
+++ b/Dockerfile.rust
@@ -1,19 +1,19 @@
-from freebsd-cross
+FROM freebsd-cross
 
 # A host compiler is needed to link Rust build scripts even when cross compiling:
-run apt update -y
-run apt install -y curl build-essential
+RUN apt update -y
+RUN apt install -y curl build-essential
 
-run curl https://sh.rustup.rs -sSf \
+RUN curl https://sh.rustup.rs -sSf \
       | sh -s -- -y --target x86_64-unknown-freebsd
 
-run mkdir -p /rust/project /rust/target
+RUN mkdir -p /rust/project /rust/target
 
-workdir /rust/project
+WORKDIR /rust/project
 
-volume /rust/project
+VOLUME /rust/project
 
-env PATH /root/.cargo/bin:/freebsd/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+ENV PATH /root/.cargo/bin:/freebsd/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
 # Required for the openssl-sys crate:
-env OPENSSL_DIR /freebsd/x86_64-pc-freebsd12/
+ENV OPENSSL_DIR /freebsd/x86_64-pc-freebsd12/

--- a/Dockerfile.rust
+++ b/Dockerfile.rust
@@ -1,25 +1,19 @@
-FROM freebsd-cross
+from freebsd-cross
 
-ENV PATH /home/rust/.cargo/bin:/freebsd/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+# A host compiler is needed to link Rust build scripts even when cross compiling:
+run apt update -y
+run apt install -y curl build-essential
 
-RUN apt-get -y update && \
-    apt-get -y install curl build-essential
-# A host compiler is needed to link Rust build scripts even when cross compiling
+run curl https://sh.rustup.rs -sSf \
+      | sh -s -- -y --target x86_64-unknown-freebsd
 
-RUN useradd -ms /bin/bash rust
+run mkdir -p /rust/project /rust/target
 
-USER rust
+workdir /rust/project
 
-RUN curl https://sh.rustup.rs -sSf | sh -s -- -y && \
-    rustup target add x86_64-unknown-freebsd
+volume /rust/project
 
-RUN mkdir -p /home/rust/code/target /home/rust/.cargo/registry /home/rust/output
+env PATH /root/.cargo/bin:/freebsd/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
-WORKDIR /home/rust/code
-
-VOLUME /home/rust/code /home/rust/code/target /home/rust/output /home/rust/.cargo/registry
-
-env OPENSSL_DIR /freebsd/x86_64-pc-freebsd12/ # required for the openssl-sys crate
-
-ENTRYPOINT ["cargo"]
-CMD ["--help"]
+# Required for the openssl-sys crate:
+env OPENSSL_DIR /freebsd/x86_64-pc-freebsd12/


### PR DESCRIPTION
The PR consists of 2 commits.

The first one is pretty straightforward, just adds an environment variable that allows building the openssl-sys crate.

The second one is a major refactor of the build script, and the base image (rust). The reasoning for such changes consists of:

1. Use the container itself as the build cache, dismissing the volume setup.
The container is a stateful component, and as such is capable of caching build artefacts. We just need to start/stop instead of delete/create.

2. Have the container run as root, allowing dependency installation after the base image.
Some projects require extra dependencies, commonly `libfl-dev` and `libsqlite3`. With the container running as root, it's easier to run the installation command for such dependencies, without having to build a new base image.

3. Remove `sudo` calls, allowing `docker cp` to setup the correct file ownership.
Without sudo, `docker cp` adjusts the files' ownership automatically. This implies the user must be in the docker group, which he should be in anyway.

4. Remove TTY allocation for container, allowing piping scripts into the container.
As the container will be mainly used in build scripts, having a nice scripting interface is preferred over having a nice interactive interface. Unfortunately, AFAIK, one can only have one with docker containers.